### PR TITLE
fix named pipe to also check for LastError ERROR_PIPE_CONNECTED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ x86
 Debug
 bin
 .vs
+.vscode
 out
 Release
 /src/ProtoInput/ProtoInputHost/imgui.ini

--- a/lib/EasyHook/EasyHook/EasyHook.csproj
+++ b/lib/EasyHook/EasyHook/EasyHook.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">netfx4-Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.50727</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/lib/EasyHook/EasyHookSvc/EasyHookSvc.csproj
+++ b/lib/EasyHook/EasyHookSvc/EasyHookSvc.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">netfx4-Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.50727</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/ProtoInput/ProtoInputLoader/InstanceHandling.cpp
+++ b/src/ProtoInput/ProtoInputLoader/InstanceHandling.cpp
@@ -51,7 +51,9 @@ void WaitClientConnect(Proto::ProtoInstance& instance)
 		while (count < 10)
 		{
 			//FIXME: This needs a timeout
-			if (ConnectNamedPipe(instance.pipeHandle, NULL))
+			auto connected = ConnectNamedPipe(instance.pipeHandle, NULL);
+			auto lastError = GetLastError();
+			if (connected || lastError == ERROR_PIPE_CONNECTED)
 			{
 				std::cout << "Connected named pipe to pid " << instance.pid << std::endl;
 				instance.clientConnected = true;


### PR DESCRIPTION
ConnectNamedPipe can return 0, but have a good connection, when a client opens the pipe between the pipe's creation and the ConnectNamedPipe call. In that case, [GetLastError() is ERROR_PIPE_CONNECTED](https://docs.microsoft.com/en-gb/windows/win32/api/namedpipeapi/nf-namedpipeapi-connectnamedpipe#return-value).

For whatever reason, the threads in the host and client hit this scenario constantly on my PC. The Host goes into an infinite loop of "failed" ConnectNamedPipe calls since it never checked GetLastError.

----

I also had to edit the EasyHook csproj files so their default Configurations correspond to Configurations those projects actually define. The ProtoInput.sln didn't build in the ms build tools developer command line. Properties set for an sln build only apply to projects directly referenced in the sln file. [If those projects reference a project not in the sln, that external project is built with its defaults.](https://github.com/dotnet/msbuild/issues/5116#issuecomment-584211463)

>This is an intentional* behavior when a build goes outside of a solution. The AssignProjectConfiguration task maps ProjectReferences to the appropriate project-level Configuration and Platform, given the active solution-level Configuration and Platform. When the referenced project is not part of the solution, there's no such mapping, and the build has to choose between passing along the referencing project's configuration or taking the referenced project's default configuration.

The csproj files for EasyHook define PropertyGroups for Configuration netfx4-Debug not Debug
>PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netfx4-Debug|AnyCPU'"

but were setting the default Configuration to Debug

>Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration

Now these commands both work

msbuild .\ProtoInput.sln /p:ConfigurationPlatforms=Debug /p:Platform="x64"
msbuild .\ProtoInput.sln /p:ConfigurationPlatforms=Debug /p:Platform="x86"